### PR TITLE
Revert logo paths to relative local assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <nav class="container mx-auto px-6 py-2 flex justify-between items-center">
             <!-- Logo -->
             <a href="#home">
-                <img id="site_logo" src="https://raw.githubusercontent.com/mariosroussos/RNA/main/assets/pictures/rna_logo.png" alt="RNA Logo" class="h-12 w-auto">
+                <img id="site_logo" src="assets/pictures/rna_logo.png" alt="RNA Logo" class="h-12 w-auto">
             </a>
             <!-- Mobile Menu Button -->
             <div class="md:hidden">
@@ -80,7 +80,7 @@
         <!-- Home Section -->
         <section id="home" class="min-h-screen flex items-center section-fade-in">
             <div class="max-w-4xl text-center mx-auto">
-                <img src="https://raw.githubusercontent.com/mariosroussos/RNA/main/assets/pictures/rna_logo.png" alt="RNA Logo Large" class="h-32 md:h-48 w-auto mx-auto mb-8">
+                <img src="assets/pictures/rna_logo.png" alt="RNA Logo Large" class="h-32 md:h-48 w-auto mx-auto mb-8">
                 <h1 id="home_headline" class="text-6xl md:text-8xl font-black tracking-tighter mb-4"></h1>
                 <p id="home_subheading" class="text-lg md:text-xl text-stone-400 max-w-3xl mx-auto"></p>
             </div>
@@ -154,7 +154,7 @@
         
         <!-- Join Section -->
         <section id="join" class="py-20 md:py-32 text-center section-fade-in">
-             <img src="https://raw.githubusercontent.com/mariosroussos/RNA/main/assets/pictures/rna_logo.png" alt="RNA Logo Small" class="h-24 w-auto mx-auto mb-8">
+             <img src="assets/pictures/rna_logo.png" alt="RNA Logo Small" class="h-24 w-auto mx-auto mb-8">
             <h2 id="join_title" class="text-4xl md:text-6xl font-black tracking-tighter mb-4"></h2>
             <p id="join_subheading" class="text-lg text-stone-400 max-w-xl mx-auto mb-8"></p>
             <a id="join_contact_button" href="#" class="inline-block bg-sky-600 hover:bg-sky-700 text-white font-bold py-4 px-8 rounded-lg text-lg transition-colors duration-300"></a>
@@ -190,7 +190,7 @@
         // All content is now stored here. Edit the values below to update the website.
         const siteData = {
             // General Site Content
-            "site_logo_url": "https://raw.githubusercontent.com/mariosroussos/RNA/main/assets/pictures/rna_logo.png",
+            "site_logo_url": "assets/pictures/rna_logo.png",
             "nav_join_button_text": "Join Us",
             "home_headline": "Running <span class='text-sky-600'>Association</span> <span class='text-amber-500'>Spata</span>",
             "home_subheading": "Το RNA:Spata είναι μια δρομική ομάδα που επαναπροσδιορίζει το τρέξιμο. Σε μια εποχή γεμάτη τεχνολογία, social media και παραπληροφόρηση, εμείς σας θυμίζουμε γιατί τρέχετε. Στόχος μας δεν είναι μόνο οι επιδόσεις, αλλά η σωματική και ψυχική σας υγεία, η χαρά της συμμετοχής και η κοινωνικοποίηση. Το τρέξιμο είναι για όλους, ένα διάλειμμα από την καθημερινότητα, μια στιγμή για εσάς. Ελάτε στην παρέα του RNA, όπου η αίσθηση μετράει περισσότερο από το ρολόι και η χαρά της άθλησης είναι το ζητούμενο..",


### PR DESCRIPTION
- Changed all logo `src` attributes in HTML (navigation, Home section, Join section) to use the relative path `assets/pictures/rna_logo.png`.
- Updated `siteData.site_logo_url` in JavaScript to also use the relative path `assets/pictures/rna_logo.png`.

This ensures that the website uses the locally stored logo image as per user clarification, rather than absolute GitHub URLs from previous merge resolution.