### PR TITLE
Update logo images and sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <nav class="container mx-auto px-6 py-2 flex justify-between items-center">
             <!-- Logo -->
             <a href="#home">
-                <img id="site_logo" src="https://placehold.co/200x100/000000/FFFFFF?text=RNA" alt="RNA Logo" class="h-12 w-auto" onerror="this.onerror=null;this.src='https://placehold.co/200x100/000000/FFFFFF?text=RNA';">
+                <img id="site_logo" src="assets/pictures/rna_logo.png" alt="RNA Logo" class="h-16 w-auto" onerror="this.onerror=null;this.src='https://placehold.co/200x100/000000/FFFFFF?text=RNA';">
             </a>
             <!-- Mobile Menu Button -->
             <div class="md:hidden flex items-center space-x-4">
@@ -81,7 +81,7 @@
         <!-- Home Section -->
         <section id="home" class="min-h-screen flex items-center section-fade-in">
             <div class="max-w-4xl text-center mx-auto">
-                <img id="home_logo" src="https://placehold.co/200x100/000000/FFFFFF?text=RNA" alt="RNA Logo Large" class="h-32 md:h-48 w-auto mx-auto mb-8" onerror="this.onerror=null;this.src='https://placehold.co/200x100/000000/FFFFFF?text=RNA';">
+                <img id="home_logo" src="assets/pictures/rna_logo.png" alt="RNA Logo Large" class="h-64 w-auto mx-auto mb-8" onerror="this.onerror=null;this.src='https://placehold.co/200x100/000000/FFFFFF?text=RNA';">
                 <h1 id="home_headline" class="text-6xl md:text-8xl font-black tracking-tighter mb-4"></h1>
                 <p id="home_subheading" class="text-lg md:text-xl text-stone-400 max-w-3xl mx-auto"></p>
             </div>
@@ -155,7 +155,7 @@
         
         <!-- Join Section -->
         <section id="join" class="py-20 md:py-32 text-center section-fade-in">
-            <img id="join_logo" src="https://placehold.co/200x100/000000/FFFFFF?text=RNA" alt="RNA Logo Small" class="h-24 w-auto mx-auto mb-8" onerror="this.onerror=null;this.src='https://placehold.co/200x100/000000/FFFFFF?text=RNA';">
+            <img id="join_logo" src="assets/pictures/rna_logo.png" alt="RNA Logo Small" class="h-32 w-auto mx-auto mb-8" onerror="this.onerror=null;this.src='https://placehold.co/200x100/000000/FFFFFF?text=RNA';">
             <h2 id="join_title" class="text-4xl md:text-6xl font-black tracking-tighter mb-4"></h2>
             <p id="join_subheading" class="text-lg text-stone-400 max-w-xl mx-auto mb-8"></p>
             <a id="join_contact_button" href="#" data-modal-trigger class="inline-block bg-sky-600 hover:bg-sky-700 text-white font-bold py-4 px-8 rounded-lg text-lg transition-colors duration-300"></a>


### PR DESCRIPTION
- Updated the source path for logos to 'assets/pictures/rna_logo.png'.
- Adjusted Tailwind CSS classes to resize logos:
  - Top left logo: medium (h-16)
  - Above title logo: very large (h-64)
  - Near contact us logo: large (h-32)
- Confirmed 'site_logo_url' in siteData JS object is correct.